### PR TITLE
Python 3 support and use Django JSON Encoder

### DIFF
--- a/django_orm_profiler/core/emitter.py
+++ b/django_orm_profiler/core/emitter.py
@@ -25,6 +25,6 @@ class Emitter(object):
     """
     def emit(self, payload):
         self.emit_socket.sendto(
-            DjangoJSONEncoder().encode(payload).encode(),
+            DjangoJSONEncoder().encode(payload).encode('UTF-8'),
             self.connection_params
         )

--- a/django_orm_profiler/core/emitter.py
+++ b/django_orm_profiler/core/emitter.py
@@ -1,5 +1,7 @@
 import socket
-import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+
 
 class Emitter(object):
 
@@ -23,6 +25,6 @@ class Emitter(object):
     """
     def emit(self, payload):
         self.emit_socket.sendto(
-            json.dumps(payload),
+            DjangoJSONEncoder().encode(payload).encode(),
             self.connection_params
         )

--- a/django_orm_profiler/core/logger.py
+++ b/django_orm_profiler/core/logger.py
@@ -1,8 +1,8 @@
 import inspect
 
-from config import ConfigLoader
-from emitter import Emitter
-from exceptions import NoCaptureFrameFoundException
+from .config import ConfigLoader
+from .emitter import Emitter
+from .exceptions import NoCaptureFrameFoundException
 
 #
 # CONSTANTS


### PR DESCRIPTION
Hi, great tool - I found it very helpful.

A few changes to support Python 3.
I also changed to using the Django JSON encoder from just the stdlibs JSON as my codebase uses UUIDs for ids